### PR TITLE
Sound fixes

### DIFF
--- a/data/panel.js
+++ b/data/panel.js
@@ -26,7 +26,7 @@ document.getElementById("clearCount").addEventListener("click", function() {
 self.port.on("show", function(currentSettings) {
   // populate the settings dialog with the current value of the settings
   playSound.checked = currentSettings.playSound;
-  document.getElementById("hangThreshold").value = currentSettings.hangThreshold;
+  hangThreshold.value = currentSettings.hangThreshold;
   switch (currentSettings.mode) {
     case "threadHangs":
       document.getElementById("countThreadHangs").checked = true;
@@ -49,16 +49,5 @@ self.port.on("warning", function(warningType) {
       break;
     default:
       banner.style.display = "none";
-  }
-});
-
-// trimmed and normalized blip sound from https://commons.wikimedia.org/wiki/File:Blip.ogg
-// available under public domain
-var blipSound = new Audio("blip.ogg");
-self.port.on("blip", function() {
-  if (playSound.checked) {
-    // play the blip sound
-    blipSound.currentTime = 0;
-    blipSound.play();
   }
 });

--- a/data/play-sound.html
+++ b/data/play-sound.html
@@ -1,0 +1,11 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Blank page for playing sounds (sounds must be played in a content process)</title>
+</head>
+
+<body>
+</body>
+</html>

--- a/data/play-sound.js
+++ b/data/play-sound.js
@@ -1,0 +1,23 @@
+// trimmed and normalized blip sound from https://commons.wikimedia.org/wiki/File:Blip.ogg
+// available under public domain
+var blipSound = new Audio("blip.ogg");
+self.port.on("blip", function(numberOfBlips) {
+  // Play no more than 10 blips; users likely won't be able to tell the difference,
+  // and we cant take too much time playing blips, or else they will not accurately represent when the hang(s) occurred
+  playBlips(Math.min(10, numberOfBlips));
+});
+
+// When multiple blips come in, play the blip sound multiple times
+function playBlips(numberOfBlips) {
+  if (numberOfBlips < 1) {
+    return;
+  }
+
+  // play the blip sound
+  blipSound.currentTime = 0;
+  blipSound.play();
+
+  setTimeout(function() {
+    playBlips(numberOfBlips - 1);
+  }, 200);
+}

--- a/index.js
+++ b/index.js
@@ -184,6 +184,10 @@ function numEventLoopLags() {
   return result;
 }
 
+var soundPlayerPage = require("sdk/page-worker").Page({
+  contentScriptFile: "./play-sound.js",
+  contentURL: "./play-sound.html",
+});
 
 const BADGE_COLOURS = ["red", "blue", "brown", "black"];
 let numHangsObserved = 0;
@@ -199,10 +203,10 @@ function updateBadge() {
     button.badgeColor = BADGE_COLOURS[button.badge % BADGE_COLOURS.length];
     panel.port.emit("warning", null);
     
-    // tell the panel to play a sound if the number of hangs has been incremented
+    // Tell the panel to play a sound if the number of hangs has been incremented
     // (we can only play sounds in documents, and the panel is conveniently a document)
-    if (prevNumHangs !== null && button.badge > prevNumHangs) {
-      panel.port.emit("blip");
+    if (gPlaySound && prevNumHangs !== null && button.badge > prevNumHangs) {
+     soundPlayerPage.port.emit("blip", button.badge - prevNumHangs);
     }
     prevNumHangs = button.badge;
   }


### PR DESCRIPTION
- Fix sounds not playing before the panel is opened if hang notification sounds was on from the previous session.
- Play multiple sounds per counter increment, up to 10 (suggested by avih).
