### PR TITLE
Show most recent hang stacks

### DIFF
--- a/data/copy-icon.svg
+++ b/data/copy-icon.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="120px" height="120px" viewBox="0 0 120 120" enable-background="new 0 0 120 120" xml:space="preserve">
+<polygon points="103.192,120 16.526,120 16.526,0 55.96,0 55.96,46.301 103.192,46.301 "/>
+<polygon points="64.476,0 64.476,38.717 103.192,38.717 "/>
+</svg>

--- a/data/panel.html
+++ b/data/panel.html
@@ -104,8 +104,8 @@
   <hr>
   <h1>MOST RECENT HANGS</h1>
   <div id="hangStacks">
-    <!-- hang stack entries are added here -->
-    <div>
+    <!-- hang stack entries are added here by `data/panel.js`, and have the following structure: -->
+    <!--<div>
       <pre class="stack">pineapple
 mango
 grapes
@@ -118,7 +118,7 @@ banana</pre>
         </button>
         <div class="timestamp">1/19/2016, 1:09:51 PM</div>
       </div>
-    </div>
+    </div>-->
   </div>
   <p class="note">The stack traces displayed here are are Background Hang Reporter pseudo-stacks. Only the 10 most recent stack traces are shown.</p>
 </body>

--- a/data/panel.html
+++ b/data/panel.html
@@ -32,6 +32,32 @@
       margin: 0;
       margin-bottom: 1em;
     }
+    #hangStacks > div {
+      margin: 10px;
+      padding: 10px;
+      min-height: 20px;
+      background: #ddd;
+      color: black;
+      font-size: 8px;
+    }
+    .copyButton {
+      padding: 0;
+      float: right;
+      width: 20px;
+      height: 20px;
+      border: 1px solid black;
+      background: white;
+      border-radius: 50%;
+    }
+    .copyButton img {
+      width: 8px;
+    }
+    .copyButton:hover {
+      background: #eee;
+    }
+    .hangContents {
+      margin-right: 30px;
+    }
   </style>
 </head>
 
@@ -58,5 +84,11 @@
   </div>
   <hr>
   <p class="note">On E10S builds, Statuser will <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1228437" target="_blank">only measure main thread hangs</a>.</p>
+  <hr>
+  <h1>MOST RECENT HANGS</h1>
+  <div id="hangStacks">
+    <!-- hang stack entries are added here -->
+  </div>
+  <p class="note">The stack traces displayed here are are Background Hang Reporter pseudo-stacks. Only the 10 most recent stack traces are shown.</p>
 </body>
 </html>

--- a/data/panel.html
+++ b/data/panel.html
@@ -13,7 +13,7 @@
     a {
       color: inherit;
     }
-    input[type="submit"] {
+    button {
       font-family: inherit;
       font-size: inherit;
     }
@@ -33,30 +33,47 @@
       margin-bottom: 1em;
     }
     #hangStacks > div {
-      margin: 10px;
-      padding: 10px;
-      min-height: 20px;
+      display: table;
+      width: 100%;
+      min-height: 30px;
+      margin: 0;
+      margin-bottom: 10px;
       background: #ddd;
       color: black;
       font-size: 8px;
     }
-    .copyButton {
+    .controls {
+      display: table-cell;
+      width: 130px;
+      padding: 5px 10px;
+      text-align: right;
+      background: #888;
+      color: white;
+      z-index: 1;
+    }
+    .controls .duration {
+      font-size: 12px;
+    }
+    .controls .timestamp {
+      margin-top: 5px;
+    }
+    .controls .copyButton {
       padding: 0;
-      float: right;
       width: 20px;
       height: 20px;
       border: 1px solid black;
       background: white;
       border-radius: 50%;
     }
-    .copyButton img {
+    .controls .copyButton img {
       width: 8px;
     }
-    .copyButton:hover {
+    .controls .copyButton:hover {
       background: #eee;
     }
-    .hangContents {
-      margin-right: 30px;
+    .stack {
+      display: table-cell;
+      padding: 10px;
     }
   </style>
 </head>
@@ -88,6 +105,20 @@
   <h1>MOST RECENT HANGS</h1>
   <div id="hangStacks">
     <!-- hang stack entries are added here -->
+    <div>
+      <pre class="stack">pineapple
+mango
+grapes
+canteloupe
+banana</pre>
+      <div class="controls">
+        <span class="duration">500-1000 ms</span>
+        <button class="copyButton" title="Copy Hang Stack">
+          <img src="copy-icon.svg" />
+        </button>
+        <div class="timestamp">1/19/2016, 1:09:51 PM</div>
+      </div>
+    </div>
   </div>
   <p class="note">The stack traces displayed here are are Background Hang Reporter pseudo-stacks. Only the 10 most recent stack traces are shown.</p>
 </body>

--- a/data/panel.js
+++ b/data/panel.js
@@ -51,3 +51,29 @@ self.port.on("warning", function(warningType) {
       banner.style.display = "none";
   }
 });
+
+self.port.on("set-hangs", function(hangStacks) {
+  var hangs = document.getElementById("hangStacks");
+  hangs.innerHTML = ""; // clear the contents of the hang stacks list
+  hangStacks.reverse().forEach((hangStack, i) => {
+    // create an entry for the hang stack
+    var entry = document.createElement("div");
+    var copyButton = document.createElement("button");
+    copyButton.innerHTML = '<img src="copy-icon.svg" />'; // public domain copy icon, taken from http://publicicons.org/file-icon/
+    copyButton.className = "copyButton";
+    copyButton.title = "Copy Hang Stack";
+    copyButton.addEventListener("click", function(event) {
+      var value = entry.getElementsByClassName("hangContents")[0].textContent;
+      self.port.emit("copy", value);
+    });
+    entry.appendChild(copyButton);
+    var contents = document.createElement("div");
+    contents.className = "hangContents";
+    contents.appendChild(document.createTextNode(hangStack));
+    entry.appendChild(contents);
+    hangs.appendChild(entry);
+  });
+  if (hangStacks.length == 0) {
+    hangs.appendChild(document.createTextNode("No hang stack traces to show."));
+  }
+});

--- a/data/panel.js
+++ b/data/panel.js
@@ -52,28 +52,43 @@ self.port.on("warning", function(warningType) {
   }
 });
 
-self.port.on("set-hangs", function(hangStacks) {
-  var hangs = document.getElementById("hangStacks");
-  hangs.innerHTML = ""; // clear the contents of the hang stacks list
-  hangStacks.reverse().forEach((hangStack, i) => {
-    // create an entry for the hang stack
+self.port.on("set-hangs", function(hangs) {
+  var entriesContainer = document.getElementById("hangStacks");
+  entriesContainer.innerHTML = ""; // clear the hang entries
+  hangs.reverse().forEach(hang => {
+    // create an entry for the hang
     var entry = document.createElement("div");
-    var copyButton = document.createElement("button");
-    copyButton.innerHTML = '<img src="copy-icon.svg" />'; // public domain copy icon, taken from http://publicicons.org/file-icon/
-    copyButton.className = "copyButton";
-    copyButton.title = "Copy Hang Stack";
-    copyButton.addEventListener("click", function(event) {
-      var value = entry.getElementsByClassName("hangContents")[0].textContent;
-      self.port.emit("copy", value);
-    });
-    entry.appendChild(copyButton);
-    var contents = document.createElement("div");
-    contents.className = "hangContents";
-    contents.appendChild(document.createTextNode(hangStack));
-    entry.appendChild(contents);
-    hangs.appendChild(entry);
+      var contents = document.createElement("pre");
+      contents.className = "stack";
+      contents.appendChild(document.createTextNode(hang.stack));
+      entry.appendChild(contents);
+      var controls = document.createElement("div");
+        controls.className = "controls";
+        var duration = document.createElement("span");
+        if (hang.upperBound == Infinity) {
+          duration.innerHTML = hang.lowerBound + "+ ms ";
+        } else {
+          duration.innerHTML = hang.lowerBound + "-" + hang.upperBound + " ms ";
+        }
+        duration.className = "duration";
+        controls.appendChild(duration);
+        var copyButton = document.createElement("button");
+        copyButton.innerHTML = '<img src="copy-icon.svg" />'; // public domain copy icon, taken from http://publicicons.org/file-icon/
+        copyButton.className = "copyButton";
+        copyButton.title = "Copy Hang Stack";
+        copyButton.addEventListener("click", function(event) {
+          var value = entry.getElementsByClassName("stack")[0].textContent;
+          self.port.emit("copy", value);
+        });
+        controls.appendChild(copyButton);
+        var timestamp = document.createElement("div");
+        timestamp.innerHTML = hang.timestamp;
+        timestamp.className = "timestamp";
+        controls.appendChild(timestamp);
+      entry.appendChild(controls);
+    entriesContainer.appendChild(entry);
   });
-  if (hangStacks.length == 0) {
-    hangs.appendChild(document.createTextNode("No hang stack traces to show."));
+  if (hangs.length == 0) {
+    entriesContainer.appendChild(document.createTextNode("No hang data available."));
   }
 });

--- a/data/panel.js
+++ b/data/panel.js
@@ -52,7 +52,7 @@ self.port.on("warning", function(warningType) {
   }
 });
 
-self.port.on("set-hangs", function(hangs) {
+function setHangs(hangs) {
   var entriesContainer = document.getElementById("hangStacks");
   entriesContainer.innerHTML = ""; // clear the hang entries
   hangs.reverse().forEach(hang => {
@@ -91,4 +91,7 @@ self.port.on("set-hangs", function(hangs) {
   if (hangs.length == 0) {
     entriesContainer.appendChild(document.createTextNode("No hang data available."));
   }
-});
+}
+
+self.port.on("set-hangs", setHangs);
+setHangs([]);


### PR DESCRIPTION
- Up to 10 of the most recent hang stacks are displayed in the panel, from most recent to least recent.
- Stacks can be copied/pasted and the list updates as new stacks come in.

It looks like this:

![screenshot from 2016-01-18 14-07-11](https://cloud.githubusercontent.com/assets/437196/12400384/adb971c6-bded-11e5-8b11-cf3184e9b4ff.png)
