### PR TITLE
Add the new input event response time lag histogram as a new mode

### DIFF
--- a/data/panel.html
+++ b/data/panel.html
@@ -84,7 +84,8 @@
   <div>
     <label><input type="radio" name="mode" id="countThreadHangs" /> Count thread hangs</label><br>
     <label><input type="radio" name="mode" id="countEventLoopLags" /> Count event loop lags</label>
-    <p class="description">Statuser can count either hangs on the main thread, or hangs on the event loop. Changing this will reset the hang counter.</p>
+    <label><input type="radio" name="mode" id="countInputEventResponseLags" /> Count input event response time lags</label>
+    <p class="description">Statuser can count hangs on the main thread, lags on the event loop, or spikes in input event response time. Changing this setting will reset the hang counter.</p>
   </div>
   <hr>
   <div>
@@ -92,8 +93,8 @@
     <p class="description">Play a blip sound when the hang count increases.</p>
   </div>
   <div>
-    <label>Minimum hang threshold: <input type="number" min="1" id="hangThreshold" /> ms</label>
-    <p class="description">Statuser will only count hangs that last at least as long as this threshold. This is rounded up to the nearest histogram bucket, so may not be exact.</p>
+    <label>Minimum hang/lag threshold: <input type="number" min="1" id="hangThreshold" /> ms</label>
+    <p class="description">Statuser will only count hangs/lags that last at least as long as this threshold. This is rounded up to the nearest histogram bucket, so may not be exact.</p>
   </div>
   <div>
     <button type="button" id="clearCount">Clear count</button>

--- a/data/panel.js
+++ b/data/panel.js
@@ -1,11 +1,15 @@
 // emit events on the panel's port for corresponding actions
 var countThreadHangs = document.getElementById("countThreadHangs");
 var countEventLoopLags = document.getElementById("countEventLoopLags");
+var countInputEventResponseLags = document.getElementById("countInputEventResponseLags");
 countThreadHangs.addEventListener("click", function() {
   self.port.emit("mode-changed", "threadHangs");
 });
 countEventLoopLags.addEventListener("click", function() {
   self.port.emit("mode-changed", "eventLoopLags");
+});
+countInputEventResponseLags.addEventListener("click", function() {
+  self.port.emit("mode-changed", "inputEventResponseLags");
 });
 var playSound = document.getElementById("playSound");
 playSound.addEventListener("change", function(event) {
@@ -34,6 +38,9 @@ self.port.on("show", function(currentSettings) {
     case "eventLoopLags":
       document.getElementById("countEventLoopLags").checked = true;
       break;
+    case "inputEventResponseLags":
+      document.getElementById("countInputEventResponseLags").checked = true;
+      break;
     default:
       console.warn("Unknown mode: ", currentSettings.mode);
   }
@@ -43,12 +50,25 @@ self.port.on("show", function(currentSettings) {
 self.port.on("warning", function(warningType) {
   var banner = document.getElementById("warningBanner");
   switch (warningType) {
+    case null:
+      banner.style.display = "none";
+      break;
     case "unavailableBHR":
       banner.innerHTML = "BACKGROUND HANG REPORTING <a href=\"about:telemetry\" target=\"_blank\">UNAVAILABLE</a>";
       banner.style.display = "block";
       break;
+    case "unavailableEventLoopLags":
+      banner.innerHTML = "EVENTLOOP_UI_ACTIVITY_EXP_MS HISTOGRAM <a href=\"about:telemetry\" target=\"_blank\">UNAVAILABLE</a>";
+      banner.style.display = "block";
+      break;
+    case "unavailableInputEventResponseLags":
+      banner.innerHTML = "INPUT_EVENT_RESPONSE_MS HISTOGRAM <a href=\"about:telemetry\" target=\"_blank\">UNAVAILABLE</a>";
+      banner.style.display = "block";
+      break;
     default:
-      banner.style.display = "none";
+      banner.innerHTML = "UNKNOWN WARNING: " + warningType;
+      banner.style.display = "block";
+      break;
   }
 });
 


### PR DESCRIPTION
- New input response lag mode using https://hg.mozilla.org/integration/fx-team/rev/677e9cf53757.
- Clarify some wording in the panel to include the new mode.
- Add warning banner for old versions of Firefox that don't have the relevant histograms in event loop lags mode and input event response lags mode.

There are a few different changes here, but they're all closely related so I put them together. Do they need splitting?
