### PR TITLE
Show uptimes

### DIFF
--- a/data/panel.html
+++ b/data/panel.html
@@ -54,7 +54,7 @@
     .controls .duration {
       font-size: 12px;
     }
-    .controls .timestamp {
+    .controls .time {
       margin-top: 5px;
     }
     .controls .copyButton {
@@ -117,10 +117,11 @@ banana</pre>
         <button class="copyButton" title="Copy Hang Stack">
           <img src="copy-icon.svg" />
         </button>
-        <div class="timestamp">1/19/2016, 1:09:51 PM</div>
+        <div class="time">1/19/2016, 1:09:51 PM</div>
+        <div class="time">912923ms uptime</div>
       </div>
     </div>-->
   </div>
-  <p class="note">The stack traces displayed here are are Background Hang Reporter pseudo-stacks. Only the 10 most recent stack traces are shown.</p>
+  <p class="note">The stack traces displayed here are are Background Hang Reporter pseudo-stacks. Only the 10 most recent stack traces are shown. Hang uptimes correspond to the X axis in the <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Performance/Profiling_with_the_Built-in_Profiler" target="_blank">Gecko Profiler addon</a> timeline.</p>
 </body>
 </html>

--- a/data/panel.js
+++ b/data/panel.js
@@ -102,9 +102,17 @@ function setHangs(hangs) {
         });
         controls.appendChild(copyButton);
         var timestamp = document.createElement("div");
-        timestamp.innerHTML = hang.timestamp;
-        timestamp.className = "timestamp";
+        timestamp.innerHTML = (new Date(hang.timestamp)).toLocaleString();
+        timestamp.className = "time";
         controls.appendChild(timestamp);
+        var uptime = document.createElement("div");
+        if (hang.uptime === null) {
+          uptime.innerHTML = "unknown uptime";
+        } else {
+          uptime.innerHTML = hang.uptime + "ms uptime";
+        }
+        uptime.className = "time";
+        controls.appendChild(uptime);
       entry.appendChild(controls);
     entriesContainer.appendChild(entry);
   });


### PR DESCRIPTION
The Gecko Profiler addon shows its timeline using the milliseconds since Firefox started. If we show these in statuser, it becomes simple to pinpoint where the hangs occur in the profiler.
