### PR TITLE
Add display of the currently used threshold to the panel

### DIFF
--- a/data/panel.html
+++ b/data/panel.html
@@ -32,6 +32,9 @@
       margin: 0;
       margin-bottom: 1em;
     }
+    #computedThreshold {
+      text-decoration: underline;
+    }
     #hangStacks > div {
       display: table;
       width: 100%;
@@ -95,7 +98,7 @@
   </div>
   <div>
     <label>Minimum hang/lag threshold: <input type="number" min="1" id="hangThreshold" /> ms</label>
-    <p class="description">Statuser will only count hangs/lags that last at least as long as this threshold. This is rounded up to the nearest histogram bucket, so may not be exact.</p>
+    <p class="description">Statuser will only count hangs/lags that last <span id="computedThreshold">UNKNOWN</span>ms or more. This is the lower bound of the nearest histogram bucket to the right.</p>
   </div>
   <div>
     <button type="button" id="clearCount">Clear count</button>

--- a/data/panel.js
+++ b/data/panel.js
@@ -123,3 +123,8 @@ function setHangs(hangs) {
 
 self.port.on("set-hangs", setHangs);
 setHangs([]);
+
+// process computed threshold changes
+self.port.on("set-computed-threshold", function(computedThreshold) {
+  document.getElementById("computedThreshold").innerHTML = computedThreshold;
+});


### PR DESCRIPTION
When using statuser, one of the most common things people get confused about is how the threshold rounding actually works.

The old behaviour is unintuitive, since a 126ms threshold maps to 128ms+ events, while a 127ms threshold maps to 256ms+ events. This patch lets us keep track of the actual threshold used in the event filtering, so we can simply show the user what's actually being filtered. Now, the behaviour is fully described by saying "the used threshold is the lower bound of the nearest histogram bucket to the right".

Also, this fixes lower bound display, which should always be an integer power of 2. Previously, it was that value minus 1, which is pretty minor but technically incorrect. And a fix for input event response time mode where it would just show a question mark badge.
