### PR TITLE
Show profiler times as a range to make it easier to pinpoint hangs

### DIFF
--- a/data/panel.html
+++ b/data/panel.html
@@ -47,7 +47,7 @@
     }
     .controls {
       display: table-cell;
-      width: 130px;
+      width: 150px;
       padding: 5px 10px;
       text-align: right;
       background: #888;
@@ -57,7 +57,7 @@
     .controls .duration {
       font-size: 12px;
     }
-    .controls .time {
+    .controls .time, .controls .uptime {
       margin-top: 5px;
     }
     .controls .copyButton {
@@ -123,7 +123,7 @@ banana</pre>
           <img src="copy-icon.svg" />
         </button>
         <div class="time">1/19/2016, 1:09:51 PM</div>
-        <div class="time">912923ms uptime</div>
+        <div class="uptime">912923ms uptime</div>
       </div>
     </div>-->
   </div>

--- a/data/panel.js
+++ b/data/panel.js
@@ -97,8 +97,10 @@ function setHangs(hangs) {
         copyButton.className = "copyButton";
         copyButton.title = "Copy Hang Stack";
         copyButton.addEventListener("click", function(event) {
-          var value = entry.getElementsByClassName("stack")[0].textContent;
-          self.port.emit("copy", value);
+          var time = entry.getElementsByClassName("time")[0].textContent;
+          var uptime = entry.getElementsByClassName("uptime")[0].textContent;
+          var stack = entry.getElementsByClassName("stack")[0].textContent;
+          self.port.emit("copy", "Hang at " + time + " (" + uptime + "):\n\n" + stack);
         });
         controls.appendChild(copyButton);
         var timestamp = document.createElement("div");
@@ -109,9 +111,9 @@ function setHangs(hangs) {
         if (hang.uptime === null) {
           uptime.innerHTML = "unknown uptime";
         } else {
-          uptime.innerHTML = Math.round(hang.uptime) + "ms uptime";
+          uptime.innerHTML = Math.round(hang.previousUptime) + "ms to " + Math.round(hang.uptime) + "ms uptime";
         }
-        uptime.className = "time";
+        uptime.className = "uptime";
         controls.appendChild(uptime);
       entry.appendChild(controls);
     entriesContainer.appendChild(entry);


### PR DESCRIPTION
- Show the profiler times as a range in the Gecko profiler.
- The timestamps are also now shown in the copied stack traces.
- Update tooltips when hovering over the toolbar icon.

Note that we actually measure the time taken rather than just using `CHECK_FOR_HANG_INTERVAL`, to account for the time taken actually doing the updating.

Also, this fixes #29.
